### PR TITLE
Implement user-role conditional form logic

### DIFF
--- a/src/components/forms/ModalEntityForm.tsx
+++ b/src/components/forms/ModalEntityForm.tsx
@@ -133,6 +133,9 @@ export const ModalEntityForm = <T extends BaseEntity = BaseEntity>({
   const [activeTab, setActiveTab] = useState<string>('');
   const [isDirty, setIsDirty] = useState(false);
 
+  // Resolve the role early so hooks can reference it
+  const role = userRole || user?.role || 'user';
+
   // Get form configuration
   const config = useMemo(() => {
     const baseConfig = getEntityFormConfig(entityType);
@@ -191,7 +194,6 @@ export const ModalEntityForm = <T extends BaseEntity = BaseEntity>({
   }, [form.values, initialValues]);
 
   // Form context for child components
-  const role = userRole || user?.role || 'user';
   const formContext: FormContext = useMemo(() => ({
     entityType,
     mode,

--- a/src/config/entityFormConfigs.ts
+++ b/src/config/entityFormConfigs.ts
@@ -13,7 +13,8 @@ import {
   FormTab,
   FormField,
   FormFieldType,
-  FormFieldValidation
+  FormFieldValidation,
+  FormContext
 } from '../types/forms';
 
 // Validation rules commonly used across forms
@@ -78,10 +79,8 @@ const commonFields: Record<string, Omit<FormField, 'id'>> = {
     placeholder: 'Enter secret information visible only to GMs',
     rows: 3,
     validation: commonValidations.description,
-    conditional: (values: any) => {
-      // TODO: Add user context to conditional logic
-      // For now, always show GM fields
-      return true;
+    conditional: (_values: any, context?: FormContext) => {
+      return context?.userRole === 'gamemaster' || context?.userRole === 'admin';
     }
   }
 };
@@ -259,10 +258,8 @@ const factionFormConfig: EntityFormConfig = {
       icon: React.createElement(IconEyeOff, { size: 16 }),
       description: 'Secret information visible only to Game Masters',
       order: 5,
-      conditional: (values: any) => {
-        // TODO: Add user context to conditional logic
-        // For now, always show GM fields
-        return true;
+      conditional: (_values: any, context?: FormContext) => {
+        return context?.userRole === 'gamemaster' || context?.userRole === 'admin';
       },
       fields: [
         {

--- a/src/tests/vitest/modalEntityForm.conditional.vitest.tsx
+++ b/src/tests/vitest/modalEntityForm.conditional.vitest.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithMantine } from '../../tests/vitest-utils/test-utils';
+import { ModalEntityForm } from '../../components/forms/ModalEntityForm';
+import { EntityType } from '../../types/forms';
+
+// Helper to render with required props
+const setup = (role: 'admin' | 'gamemaster' | 'player' | 'user') => {
+  renderWithMantine(
+    <ModalEntityForm
+      entityType={EntityType.FACTION}
+      opened={true}
+      onClose={() => {}}
+      worldId="world1"
+      userRole={role}
+    />
+  );
+};
+
+describe('ModalEntityForm role-based conditionals', () => {
+  it('hides GM-only tab and fields for non-GM users', () => {
+    setup('player');
+    expect(screen.queryByText('GM Secrets')).not.toBeInTheDocument();
+    expect(screen.queryByText('Secret Notes (GM Only)')).not.toBeInTheDocument();
+  });
+
+  it('shows GM-only tab for gamemaster', () => {
+    setup('gamemaster');
+    expect(screen.getByText('GM Secrets')).toBeInTheDocument();
+  });
+});

--- a/src/types/forms.ts
+++ b/src/types/forms.ts
@@ -63,7 +63,7 @@ export interface FormField {
   description?: string;
   defaultValue?: any;
   validation?: FormFieldValidation;
-  conditional?: (values: any) => boolean;
+  conditional?: (values: any, context?: FormContext) => boolean;
   options?: FormFieldOption[];
   entityType?: EntityType;
   multiple?: boolean;
@@ -102,7 +102,7 @@ export interface FormTab {
   icon?: ReactNode;
   description?: string;
   fields: FormField[];
-  conditional?: (values: any, user?: any) => boolean;
+  conditional?: (values: any, context?: FormContext) => boolean;
   order: number;
 }
 
@@ -133,6 +133,7 @@ export interface ModalEntityFormProps<T extends BaseEntity = BaseEntity> {
   initialValues?: Partial<T>;
   mode?: FormMode;
   config?: Partial<EntityFormConfig>;
+  userRole?: 'admin' | 'gamemaster' | 'player' | 'user';
 }
 
 // Form submission data
@@ -182,6 +183,7 @@ export interface FormContext {
   errors: Record<string, string>;
   isSubmitting: boolean;
   isDirty: boolean;
+  userRole?: 'admin' | 'gamemaster' | 'player' | 'user';
 }
 
 // User role for conditional field rendering


### PR DESCRIPTION
## Summary
- expose userRole in form context and props
- update entity form config conditionals to check userRole
- filter fields and tabs based on userRole
- provide unit test for GM-only visibility

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842947c945c832997c3fe482fae4a21