### PR TITLE
Implement basic proposal management

### DIFF
--- a/docs/proposal-system-overview.md
+++ b/docs/proposal-system-overview.md
@@ -1,0 +1,14 @@
+# Proposal System Overview
+
+This document outlines how player submitted proposals are reviewed within RPG Scribe.
+
+## Workflow
+
+1. **Submission** – Players create proposals using the UI. Each proposal is stored under `proposals/{proposalId}` in Firestore with a `submittedBy` user id and timestamp.
+2. **Review** – Game Masters open the proposal list to review pending items. They can approve or reject individual proposals. Approved or rejected proposals record the reviewer and review time.
+3. **Implementation** – Approved proposals are applied to campaign data in future updates (not yet automated).
+
+## Comment Guidelines
+
+- Keep feedback concise and specific so players understand any changes made by the GM.
+- Provide reasons when rejecting a proposal to encourage constructive collaboration.

--- a/docs/proposal-system-overview.md
+++ b/docs/proposal-system-overview.md
@@ -5,7 +5,7 @@ This document outlines how player submitted proposals are reviewed within RPG Sc
 ## Workflow
 
 1. **Submission** – Players create proposals using the UI. Each proposal is stored under `proposals/{proposalId}` in Firestore with a `submittedBy` user id and timestamp.
-2. **Review** – Game Masters open the proposal list to review pending items. They can approve or reject individual proposals. Approved or rejected proposals record the reviewer and review time.
+2. **Review** – Game Masters open the proposal list to review pending items. Only GMs can approve or reject individual proposals. Approved or rejected proposals record the reviewer and review time.
 3. **Implementation** – Approved proposals are applied to campaign data in future updates (not yet automated).
 
 ## Comment Guidelines

--- a/firestore.rules
+++ b/firestore.rules
@@ -102,11 +102,18 @@ service cloud.firestore {
     
     // Campaign access control
     match /campaignAccess/{campaignId}/users/{userId} {
-      allow read: if isSignedIn() && (request.auth.uid == userId || 
+      allow read: if isSignedIn() && (request.auth.uid == userId ||
                                      get(/databases/$(database)/documents/campaigns/$(campaignId)).data.createdBy == request.auth.uid ||
                                      isAdmin());
       allow write: if isSignedIn() && (get(/databases/$(database)/documents/campaigns/$(campaignId)).data.createdBy == request.auth.uid ||
                                       isAdmin());
+    }
+
+    // AI Proposals
+    match /proposals/{proposalId} {
+      allow read: if isSignedIn() && hasAccess(resource.data.campaignId);
+      allow create: if isSignedIn() && hasAccess(request.resource.data.campaignId);
+      allow update, delete: if isGameMaster() && hasAccess(resource.data.campaignId);
     }
   }
 }

--- a/src/components/ai/AIProposalCard.tsx
+++ b/src/components/ai/AIProposalCard.tsx
@@ -126,6 +126,10 @@ export function AIProposalCard({
         </Badge>
       </Group>
 
+      <Text size="xs" c="dimmed" mb="sm">
+        Submitted by {proposal.submittedBy} on {proposal.submittedAt.toLocaleString()}
+      </Text>
+
       <Text size="sm" c="dimmed" mb="md">
         AI Confidence: {formatConfidence(proposal.aiConfidence)}
       </Text>

--- a/src/models/AIProposal.ts
+++ b/src/models/AIProposal.ts
@@ -57,6 +57,8 @@ export interface AIProposal {
   campaignId: string;
   entityId?: string;
   entityType?: EntityType;
+  submittedBy: string;
+  submittedAt: Date;
   proposalType: ProposalType;
   status: ProposalStatus;
   changes: ChangeField[];
@@ -77,11 +79,13 @@ export interface AIProposalCreationParams {
   campaignId: string;
   entityId?: string;
   entityType?: EntityType;
+  submittedBy: string;
   proposalType: ProposalType;
   changes: ChangeField[];
   relationshipChanges?: RelationshipChange[];
   aiConfidence: number;
   aiReasoning: string;
+  submittedAt?: Date;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `submittedBy` and `submittedAt` fields to `AIProposal` model
- implement Firestore CRUD for proposals in `aiBrain.service`
- fetch proposals and send approve/reject updates from UI
- display submission info on proposal cards
- restrict proposal approval to GMs in rules
- document proposal workflow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429fd365908329b0985743be526971